### PR TITLE
DM-13530: Generalize ingestion to non-HiTS data

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ path                  | description
 :---------------------|:-----------------------------
 `raw`                 | Raw, compressed DECam fits images from the HiTS (2015) fields `Blind15A_26`, `Blind15A_40`, and `Blind15A_42`.
 `calib`               | DECam master calibs and `wtmap`s from the 2015 HiTS campaign. No raw images. See below for filename information.
+`config`              | Dataset-specific configs to help Stack code work with this dataset.
 `templates`           | Butler repo containing coadded images intended to be used as templates.
 `repo`                | Butler repo into which raw data can be ingested. This should be copied to an appropriate location before ingestion. Currently contains the appropriate DECam `_mapper` file.
 `refcats`             | Tarballs of Gaia and PS1 reference catalogs in HTM format for regions overlapping all three HiTS fields.

--- a/config/datasetIngest.py
+++ b/config/datasetIngest.py
@@ -1,0 +1,23 @@
+import os.path
+
+from lsst.utils import getPackageDir
+from lsst.obs.decam.ingest import DecamIngestTask
+
+obsConfigDir = os.path.join(getPackageDir('obs_decam'), 'config')
+
+config.dataIngester.retarget(DecamIngestTask)
+config.dataIngester.load(os.path.join(obsConfigDir, 'ingest.py'))
+
+config.calibIngester.load(os.path.join(obsConfigDir, 'ingestCalibs.py'))
+# Ignore wtmaps and illumcors
+# These data products may be useful in the future, but are not yet supported by the Stack
+# and will confuse the ingester
+config.calibBadFiles = ['*_fcw_*', '*_zcw_*', '*_ici_*']
+
+config.defectIngester.load(os.path.join(obsConfigDir, 'ingestCalibs.py'))
+config.defectTarball = 'defects_2014-12-05.tar.gz'
+
+config.refcats = {
+    'gaia': 'gaia_HiTS_2015.tar.gz',
+    'pan-starrs': 'ps1_HiTS_2015.tar.gz'
+    }

--- a/config/datasetIngest.py
+++ b/config/datasetIngest.py
@@ -1,20 +1,8 @@
-import os.path
-
-from lsst.utils import getPackageDir
-from lsst.obs.decam.ingest import DecamIngestTask
-
-obsConfigDir = os.path.join(getPackageDir('obs_decam'), 'config')
-
-config.dataIngester.retarget(DecamIngestTask)
-config.dataIngester.load(os.path.join(obsConfigDir, 'ingest.py'))
-
-config.calibIngester.load(os.path.join(obsConfigDir, 'ingestCalibs.py'))
 # Ignore wtmaps and illumcors
 # These data products may be useful in the future, but are not yet supported by the Stack
 # and will confuse the ingester
 config.calibBadFiles = ['*_fcw_*', '*_zcw_*', '*_ici_*']
 
-config.defectIngester.load(os.path.join(obsConfigDir, 'ingestCalibs.py'))
 config.defectTarball = 'defects_2014-12-05.tar.gz'
 
 config.refcats = {


### PR DESCRIPTION
This PR adds HiTS-specific information to the dataset, keeping `ap_verify` from having to hardcode it.