### PR TITLE
DM-14557: Add package docs to datasets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+doc/_build
+

--- a/doc/ap_verify_hits2015/index.rst
+++ b/doc/ap_verify_hits2015/index.rst
@@ -1,0 +1,42 @@
+.. _ap_verify_hits2015-package:
+
+##################
+ap_verify_hits2015
+##################
+
+The ``ap_verify_hits2015`` package represents a small subset of the DECam `HiTS`_ survey.
+It is a good example dataset for difference imaging with DECam.
+
+.. _HiTS: https://doi.org/10.3847/0004-637X/832/2/155
+
+Project info
+============
+
+Repository
+   https://github.com/lsst/ap_verify_hits2015
+
+.. Datasets do not have their own (or a collective) Jira components; by convention we include them in ap_verify
+
+Jira component
+   `ap_verify <https://jira.lsstcorp.org/issues/?jql=project %3D DM %20AND%20 component %3D ap_verify %20AND%20 text ~ "hits2015">`_
+
+Dataset Contents
+================
+
+This package provides complete data for three fields from the 2015 `HiTS`_ survey.
+It contains:
+
+* raw images from the ``Blind15A_26``, ``Blind15A_40``, and ``Blind15A_42`` survey fields, in g band.
+* biases (``zci``), flats (``fci``), and corresponding weight maps (``zcw``, ``fcw``) in all DECam bands (ugriz, Y, VR). [Note: weights are not currently used by `ap_verify` or `ap_pipe`]
+* illumination corrections (``ici``) in g, r, and i band. [Note: illumcors are not currently used by `ap_verify` or `ap_pipe`]
+* defect masks (``bpm``) from December 5, 2014.
+* reference catalogs for Gaia DR1 and Pan-STARRS1, covering the raw images' footprint.
+* image differencing templates coadded from HiTS 2014 data, covering the raw images' footprint.
+
+Intended Use
+============
+
+This dataset is designed for medium-scale difference imaging analysis, using "deep" coadd templates, by ``ap_verify``.
+It can also be used for difference imaging with single-image templates, but the single-season coverage of the raw data means the resulting difference images may be low quality.
+
+The HiTS survey has a high cadence compared to other DECam datasets, so this dataset is good for testing cadence-sensitive applications.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,0 +1,12 @@
+"""Sphinx configuration file for an LSST stack package.
+
+This configuration only affects single-package Sphinx documenation builds.
+"""
+
+from documenteer.sphinxconfig.stackconf import build_package_configs
+
+
+_g = globals()
+_g.update(build_package_configs(
+    project_name='ap_verify_hits2015',))
+

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,0 +1,13 @@
+########################################
+ap_verify_hits2015 documentation preview
+########################################
+
+.. This page is for local development only. It isn't published to pipelines.lsst.io.
+
+.. Link the index pages of package and module documentation directions (listed in manifest.yaml).
+
+.. toctree::
+   :maxdepth: 1
+
+   ap_verify_hits2015/index
+

--- a/doc/manifest.yaml
+++ b/doc/manifest.yaml
@@ -1,0 +1,16 @@
+# Documentation manifest.
+
+# Name of this package
+# Also the name of the package documentation subdirectory.
+package: "ap_verify_hits2015"
+
+# List of names of Python modules in this package.
+# For each module there is a corresponding module doc subdirectory.
+# modules:
+#   - "lsst.ap.verify.hits2015"
+
+# Name of the static content directories (subdirectories of `_static`).
+# Static content directories are usually named after the package.
+# statics:
+#   - "_static/ap_verify_hits2015"
+


### PR DESCRIPTION
This PR documents the HiTS 2015 dataset; the documentation will be reachable from `ap_verify`'s list of supported datasets.