### PR TITLE
DM-14593: Clarify use of repo subdirectory in ap_verify_hits2015 dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ path                  | description
 `calib`               | DECam master calibs and `wtmap`s from the 2015 HiTS campaign. No raw images. See below for filename information.
 `config`              | Dataset-specific configs to help Stack code work with this dataset.
 `templates`           | Butler repo containing coadded images intended to be used as templates.
-`repo`                | Butler repo into which raw data can be ingested. This should be copied to an appropriate location before ingestion. Currently contains the appropriate DECam `_mapper` file.
+`repo`                | A template for a Butler raw data repository. This directory must never be written to; instead, it should be copied to a separate location, and data ingested into the copy (this is handled automatically by `ap_verify`, see below). Currently contains the appropriate DECam `_mapper` file.
 `refcats`             | Tarballs of Gaia and PS1 reference catalogs in HTM format for regions overlapping all three HiTS fields.
 `dataIds.list`        | List of dataIds for use in running Tasks. Currently set to run all Ids.
 
@@ -34,3 +34,22 @@ To clone and use this repository, you'll need Git Large File Storage (LFS).
 
 Our [Developer Guide](http://developer.lsst.io/en/latest/tools/git_lfs.html) explains how to setup Git LFS for LSST development.
 
+Usage
+-----
+
+<!-- TODO: replace with just links to Sphinx labels `ap-verify-datasets-install` and `ap-verify-running` once those docs are published -->
+
+This dataset must be cloned (with Git LFS) and set up with [EUPS](https://developer.lsst.io/stack/eups-tutorial.html) before it can be processed with `ap_verify`:
+
+    git clone https://github.com/lsst/ap_verify_hits2015/
+    setup -r ap_verify_hits2015
+
+Then, run `ap_verify` to ingest and process the dataset through the AP pipeline:
+
+    ap_verify.py --dataset HiTS2015 --id "visit=54123 ccdnum=25 filter=g" --output /my_output_dir/ --silent
+
+or, instead, run `ingest_dataset` to create standard Butler repositories for other purposes
+
+    ingest_dataset.py --dataset HiTS2015 --output /my_output_dir/
+
+See the [`ap_verify`](https://github.com/lsst-dm/ap_verify/) documentation for more details.


### PR DESCRIPTION
This PR adds a minimal usage guide to the Readme. The guide assumes that `ap_verify` is already installed and only this dataset is new.