### PR TITLE
DM-15872: Incorporate AP documentation into pipelines.lsst.io

### DIFF
--- a/doc/ap_verify_hits2015/index.rst
+++ b/doc/ap_verify_hits2015/index.rst
@@ -4,7 +4,7 @@
 ap_verify_hits2015
 ##################
 
-The ``ap_verify_hits2015`` package represents a small subset of the DECam `HiTS`_ survey, formatted for use with `lsst.ap.verify`.
+The ``ap_verify_hits2015`` package represents a small subset of the DECam `HiTS`_ survey, formatted for use with :doc:`/modules/lsst.ap.verify/index`.
 It is a good example dataset for difference imaging with DECam.
 
 .. _HiTS: https://doi.org/10.3847/0004-637X/832/2/155
@@ -14,7 +14,7 @@ It is a good example dataset for difference imaging with DECam.
 Using ap_verify_hits2015
 ========================
 
-This dataset is designed for medium-scale difference imaging analysis, using "deep" coadd templates, by `lsst.ap.verify`.
+This dataset is designed for medium-scale difference imaging analysis, using "deep" coadd templates, by :doc:`/modules/lsst.ap.verify/index`.
 It can also be used for difference imaging with single-image templates, but the single-season coverage of the raw data means the resulting difference images may be low quality.
 
 The HiTS survey has a high cadence compared to other DECam datasets, so this dataset is good for testing cadence-sensitive applications.

--- a/doc/ap_verify_hits2015/index.rst
+++ b/doc/ap_verify_hits2015/index.rst
@@ -4,39 +4,45 @@
 ap_verify_hits2015
 ##################
 
-The ``ap_verify_hits2015`` package represents a small subset of the DECam `HiTS`_ survey.
+The ``ap_verify_hits2015`` package represents a small subset of the DECam `HiTS`_ survey, formatted for use with `lsst.ap.verify`.
 It is a good example dataset for difference imaging with DECam.
 
 .. _HiTS: https://doi.org/10.3847/0004-637X/832/2/155
 
-Project info
-============
+.. _ap_verify_hits2015-using:
 
-Repository
-   https://github.com/lsst/ap_verify_hits2015
+Using ap_verify_hits2015
+========================
 
-.. Datasets do not have their own (or a collective) Jira components; by convention we include them in ap_verify
+This dataset is designed for medium-scale difference imaging analysis, using "deep" coadd templates, by `lsst.ap.verify`.
+It can also be used for difference imaging with single-image templates, but the single-season coverage of the raw data means the resulting difference images may be low quality.
 
-Jira component
-   `ap_verify <https://jira.lsstcorp.org/issues/?jql=project %3D DM %20AND%20 component %3D ap_verify %20AND%20 text ~ "hits2015">`_
+The HiTS survey has a high cadence compared to other DECam datasets, so this dataset is good for testing cadence-sensitive applications.
 
-Dataset Contents
+.. _ap_verify_hits2015-contents:
+
+Dataset contents
 ================
 
 This package provides complete data for three fields from the 2015 `HiTS`_ survey.
 It contains:
 
 * raw images from the ``Blind15A_26``, ``Blind15A_40``, and ``Blind15A_42`` survey fields, in g band.
-* biases (``zci``), flats (``fci``), and corresponding weight maps (``zcw``, ``fcw``) in all DECam bands (ugriz, Y, VR). [Note: weights are not currently used by `ap_verify` or `ap_pipe`]
-* illumination corrections (``ici``) in g, r, and i band. [Note: illumcors are not currently used by `ap_verify` or `ap_pipe`]
+* biases (``zci``), flats (``fci``), and corresponding weight maps (``zcw``, ``fcw``) in all DECam bands (ugriz, Y, VR). [Note: weights are not currently used by ``ap_verify`` or ``ap_pipe``]
+* illumination corrections (``ici``) in g, r, and i band. [Note: illumcors are not currently used by ``ap_verify`` or ``ap_pipe``]
 * defect masks (``bpm``) from December 5, 2014.
 * reference catalogs for Gaia DR1 and Pan-STARRS1, covering the raw images' footprint.
 * image differencing templates coadded from HiTS 2014 data, covering the raw images' footprint.
 
-Intended Use
+.. _ap_verify_hits2015-contributing:
+
+Contributing
 ============
 
-This dataset is designed for medium-scale difference imaging analysis, using "deep" coadd templates, by ``ap_verify``.
-It can also be used for difference imaging with single-image templates, but the single-season coverage of the raw data means the resulting difference images may be low quality.
+``ap_verify_hits2015`` is developed at https://github.com/lsst/ap_verify_hits2015.
+You can find Jira issues for this module under the `ap_verify <https://jira.lsstcorp.org/issues/?jql=project%20%3D%20DM%20AND%20component%20%3D%20ap_verify%20AND%20text~"hits2015">`_ component.
 
-The HiTS survey has a high cadence compared to other DECam datasets, so this dataset is good for testing cadence-sensitive applications.
+.. If there are topics related to developing this module (rather than using it), link to this from a toctree placed here.
+
+.. .. toctree::
+..    :maxdepth: 1

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -10,4 +10,3 @@ ap_verify_hits2015 documentation preview
    :maxdepth: 1
 
    ap_verify_hits2015/index
-

--- a/doc/manifest.yaml
+++ b/doc/manifest.yaml
@@ -4,13 +4,8 @@
 # Also the name of the package documentation subdirectory.
 package: "ap_verify_hits2015"
 
-# List of names of Python modules in this package.
-# For each module there is a corresponding module doc subdirectory.
-# modules:
-#   - "lsst.ap.verify.hits2015"
-
 # Name of the static content directories (subdirectories of `_static`).
 # Static content directories are usually named after the package.
+# Most packages do not need a static content directory (leave commented out).
 # statics:
 #   - "_static/ap_verify_hits2015"
-


### PR DESCRIPTION
This PR updates the documentation to current data package conventions and fixes build errors detected when building with `pipelines_lsst_io`. Note that this documentation is not currently being built by pipelines.lsst.io (to avoid having to download the entire package), so it may bitrot in the future.