### PR TITLE
DM-16302: ap_verify_hits2015 readme has invalid visit ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ This dataset must be cloned (with Git LFS) and set up with [EUPS](https://develo
 
 Then, run `ap_verify` to ingest and process the dataset through the AP pipeline:
 
-    ap_verify.py --dataset HiTS2015 --id "visit=54123 ccdnum=25 filter=g" --output /my_output_dir/ --silent
+    ap_verify.py --dataset HiTS2015 --id "visit=411822 ccdnum=25 filter=g" --output /my_output_dir/ --silent
 
 or, instead, run `ingest_dataset` to create standard Butler repositories for other purposes
 

--- a/doc/ap_verify_hits2015/index.rst
+++ b/doc/ap_verify_hits2015/index.rst
@@ -4,7 +4,7 @@
 ap_verify_hits2015
 ##################
 
-The ``ap_verify_hits2015`` package represents a small subset of the DECam `HiTS`_ survey, formatted for use with :doc:`/modules/lsst.ap.verify/index`.
+The ``ap_verify_hits2015`` package represents a small subset of the DECam `HiTS`_ survey, formatted for use with :doc:`lsst.ap.verify </modules/lsst.ap.verify/index>`.
 It is a good example dataset for difference imaging with DECam.
 
 .. _HiTS: https://doi.org/10.3847/0004-637X/832/2/155
@@ -14,7 +14,7 @@ It is a good example dataset for difference imaging with DECam.
 Using ap_verify_hits2015
 ========================
 
-This dataset is designed for medium-scale difference imaging analysis, using "deep" coadd templates, by :doc:`/modules/lsst.ap.verify/index`.
+This dataset is designed for medium-scale difference imaging analysis, using "deep" coadd templates, by :doc:`lsst.ap.verify </modules/lsst.ap.verify/index>`.
 It can also be used for difference imaging with single-image templates, but the single-season coverage of the raw data means the resulting difference images may be low quality.
 
 The HiTS survey has a high cadence compared to other DECam datasets, so this dataset is good for testing cadence-sensitive applications.

--- a/doc/ap_verify_hits2015/index.rst
+++ b/doc/ap_verify_hits2015/index.rst
@@ -27,7 +27,18 @@ Dataset contents
 This package provides complete data for three fields from the 2015 `HiTS`_ survey.
 It contains:
 
-* raw images from the ``Blind15A_26``, ``Blind15A_40``, and ``Blind15A_42`` survey fields, in g band.
+* raw images for three fields, in g band:
+    * 28 visits to ``Blind15A_26``: visit IDs 410915, 410971, 411021, 411055, 411255, 411305, 411355, 411406, 411456, 411657, 411707, 411758, 411808, 411858, 412060, 412250, 412307, 412504, 412554, 412604, 412654, 412704, 413635, 413680, 415314, 415364, 419791, 421590
+    * 28 visits to ``Blind15A_40``: visit IDs 410929, 410985, 411035, 411069, 411269, 411319, 411369, 411420, 411470, 411671, 411721, 411772, 411822, 411872, 412074, 412264, 412321, 412518, 412568, 412618, 412668, 412718, 413649, 413694, 415328, 415378, 419802, 421604
+    * 28 visits to ``Blind15A_42``: visit IDs 410931, 410987, 411037, 411071, 411271, 411321, 411371, 411422, 411472, 411673, 411724, 411774, 411824, 411874, 412076, 412266, 412324, 412520, 412570, 412620, 412670, 412720, 413651, 413696, 415330, 415380, 419804, 421606
+* raw images for three fields, in r band:
+    * 5 visits to ``Blind15A_26``: visit IDs 410865, 413585, 415274, 419383, 421552
+    * 7 visits to ``Blind15A_40``: visit IDs 410879, 411722, 412322, 413599, 415282, 419394, 421563
+    * 5 visits to ``Blind15A_42``: visit IDs 410881, 413601, 415284, 419396, 421565
+* raw images for three fields, in i band:
+    * 2 visits to ``Blind15A_26``: visit IDs 419418, 421500
+    * 2 visits to ``Blind15A_40``: visit IDs 419820, 421514
+    * 2 visits to ``Blind15A_42``: visit IDs 419822, 421516
 * biases (``zci``), flats (``fci``), and corresponding weight maps (``zcw``, ``fcw``) in all DECam bands (ugriz, Y, VR). [Note: weights are not currently used by ``ap_verify`` or ``ap_pipe``]
 * illumination corrections (``ici``) in g, r, and i band. [Note: illumcors are not currently used by ``ap_verify`` or ``ap_pipe``]
 * defect masks (``bpm``) from December 5, 2014.


### PR DESCRIPTION
This PR not only fixes the readme, as requested, but adds a complete list of visit numbers to the Sphinx docs for future reference.