### PR TITLE
DM-23616: Run converted ap_verify testdata through gen3 pipeline

### DIFF
--- a/config/apPipe.py
+++ b/config/apPipe.py
@@ -10,7 +10,5 @@ config.ccdProcessor.load(os.path.join(decamConfigDir, "processCcd.py"))
 # Use dataset's reference catalogs
 config.ccdProcessor.calibrate.load(os.path.join(configDir, 'calibrate.py'))
 
-# Templates are deepCoadds assembled with the CompareWarp algorithm
-config.differencer.coaddName = "deep"
-config.differencer.getTemplate.coaddName = config.differencer.coaddName
-config.differencer.getTemplate.warpType = "direct"
+# Use dataset's specific templates
+config.differencer.load(os.path.join(configDir, 'imageDifference.py'))

--- a/config/apPipe.py
+++ b/config/apPipe.py
@@ -5,8 +5,7 @@ from lsst.meas.algorithms import LoadIndexedReferenceObjectsTask
 
 decamConfigDir = os.path.join(getPackageDir('obs_decam'), 'config')
 
-# Use Community Pipeline calibration products instead of the defaults
-config.ccdProcessor.load(os.path.join(decamConfigDir, "processCcdCpIsr.py"))
+config.ccdProcessor.load(os.path.join(decamConfigDir, "processCcd.py"))
 
 # Use gaia for astrometry (phot_g_mean for everything, as that is the broadest
 # band with the most depth)

--- a/config/apPipe.py
+++ b/config/apPipe.py
@@ -1,43 +1,16 @@
 # Config override for lsst.ap.pipe.ApPipeTask
 import os.path
 from lsst.utils import getPackageDir
-from lsst.meas.algorithms import LoadIndexedReferenceObjectsTask
 
+configDir = os.path.dirname(__file__)
 decamConfigDir = os.path.join(getPackageDir('obs_decam'), 'config')
 
 config.ccdProcessor.load(os.path.join(decamConfigDir, "processCcd.py"))
 
-# Use gaia for astrometry (phot_g_mean for everything, as that is the broadest
-# band with the most depth)
-# Use panstarrs for photometry (grizy filters)
-for refObjLoader in (config.ccdProcessor.calibrate.astromRefObjLoader,
-                     config.ccdProcessor.calibrate.photoRefObjLoader,):
-    refObjLoader.retarget(LoadIndexedReferenceObjectsTask)
-config.ccdProcessor.calibrate.connections.astromRefCat = "gaia"
-config.ccdProcessor.calibrate.astromRefObjLoader.ref_dataset_name = \
-    config.ccdProcessor.calibrate.connections.astromRefCat
-config.ccdProcessor.calibrate.astromRefObjLoader.filterMap = {
-    "u": "phot_g_mean",
-    "g": "phot_g_mean",
-    "r": "phot_g_mean",
-    "i": "phot_g_mean",
-    "z": "phot_g_mean",
-    "y": "phot_g_mean",
-    "VR": "phot_g_mean"}
-config.ccdProcessor.calibrate.connections.photoRefCat = "panstarrs"
-config.ccdProcessor.calibrate.photoRefObjLoader.ref_dataset_name = \
-    config.ccdProcessor.calibrate.connections.photoRefCat
-config.ccdProcessor.calibrate.photoRefObjLoader.filterMap = {
-    "u": "g",
-    "g": "g",
-    "r": "r",
-    "i": "i",
-    "z": "z",
-    "y": "y",
-    "VR": "g"}
+# Use dataset's reference catalogs
+config.ccdProcessor.calibrate.load(os.path.join(configDir, 'calibrate.py'))
 
 # Templates are deepCoadds assembled with the CompareWarp algorithm
 config.differencer.coaddName = "deep"
 config.differencer.getTemplate.coaddName = config.differencer.coaddName
 config.differencer.getTemplate.warpType = "direct"
-

--- a/config/calibrate.py
+++ b/config/calibrate.py
@@ -1,0 +1,29 @@
+# Config override for lsst.pipe.tasks.calibrate.CalibrateTask
+from lsst.meas.algorithms import LoadIndexedReferenceObjectsTask
+
+# Use gaia for astrometry (phot_g_mean for everything, as that is the broadest
+# band with the most depth)
+# Use panstarrs for photometry (grizy filters)
+for refObjLoader in (config.astromRefObjLoader,
+                     config.photoRefObjLoader,):
+    refObjLoader.retarget(LoadIndexedReferenceObjectsTask)
+config.connections.astromRefCat = "gaia"
+config.astromRefObjLoader.ref_dataset_name = config.connections.astromRefCat
+config.astromRefObjLoader.filterMap = {
+    "u": "phot_g_mean",
+    "g": "phot_g_mean",
+    "r": "phot_g_mean",
+    "i": "phot_g_mean",
+    "z": "phot_g_mean",
+    "y": "phot_g_mean",
+    "VR": "phot_g_mean"}
+config.connections.photoRefCat = "panstarrs"
+config.photoRefObjLoader.ref_dataset_name = config.connections.photoRefCat
+config.photoRefObjLoader.filterMap = {
+    "u": "g",
+    "g": "g",
+    "r": "r",
+    "i": "i",
+    "z": "z",
+    "y": "y",
+    "VR": "g"}

--- a/config/convertRepo.py
+++ b/config/convertRepo.py
@@ -1,0 +1,7 @@
+# Config overrides for convert_gen2_repo_to_gen3.py
+
+config.refCats = ['gaia', 'panstarrs']
+
+# Need to specify runs for each refcat
+for refcat in config.refCats:
+    config.runs[refcat] = "refcats"

--- a/config/imageDifference.py
+++ b/config/imageDifference.py
@@ -1,0 +1,5 @@
+# Config override for lsst.pipe.tasks.imageDifference.ImageDifferenceTask
+# Templates are deepCoadds assembled with the CompareWarp algorithm
+config.coaddName = "deep"
+config.getTemplate.coaddName = config.coaddName
+config.getTemplate.warpType = "direct"


### PR DESCRIPTION
This PR updates the dataset config to match the changes made in lsst/obs_decam#135. It also adds a configuration file for migrating an ingested dataset from Gen 2 to Gen 3.

The changes should be identical to those on lsst/ap_verify_ci_hits2015#9.