### PR TITLE
DM-27165: Calibration ingestion produces registry where butler cannot find matching calib product

### DIFF
--- a/config/datasetIngest.py
+++ b/config/datasetIngest.py
@@ -7,3 +7,8 @@ config.refcats = {
     'gaia': 'gaia_HiTS_2015.tar.gz',
     'panstarrs': 'ps1_HiTS_2015.tar.gz'
     }
+
+# This option allows "community pipeline produced" calibrations to be
+# ingested correctly, preventing the case in which some dates are
+# unable to find the correct calibration.
+config.calibIngester.register.incrementValidEnd = False


### PR DESCRIPTION
Do not increment the validEnd on calib ingest.