### PR TITLE
DM-30199: Mark ap_verify dataset files as generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,3 +7,7 @@
 preloaded/calib/DECam/cpBias !filter !diff !merge
 preloaded/calib/DECam/cpFlat !filter !diff !merge
 preloaded/templates/ !filter !diff !merge
+
+# Must be updated any time Gen 3 repository is updated, but most changes
+# are not human-meaningful.
+config/export.yaml linguist-generated=true


### PR DESCRIPTION
This PR flags `config/export.yaml` as a machine-generated file. The primary benefit of doing so is that it will no longer appear as reviewable changes in repository updates.