### PR TITLE
DM-31190: Use CP calibrations regardless of instrument defaults.

### DIFF
--- a/config/apPipe.py
+++ b/config/apPipe.py
@@ -7,6 +7,9 @@ decamConfigDir = os.path.join(getPackageDir('obs_decam'), 'config')
 
 config.ccdProcessor.load(os.path.join(decamConfigDir, "processCcd.py"))
 
+# Use CP calibrations
+config.ccdProcessor.isr.load(os.path.join(configDir, 'isr.py'))
+
 # Use dataset's reference catalogs
 config.ccdProcessor.calibrate.load(os.path.join(configDir, 'calibrate.py'))
 

--- a/config/isr.py
+++ b/config/isr.py
@@ -1,0 +1,8 @@
+# Config override for lsst.ip.isr.IsrTask
+
+# This dataset contains CP calibs, not regular ones
+config.connections.bias = "cpBias"
+config.connections.flat = "cpFlat"
+# For Gen 2 support
+config.biasDataProductName = config.connections.bias
+config.flatDataProductName = config.connections.flat


### PR DESCRIPTION
This PR explicitly requires CP calibrations (i.e., what's actually provided in the dataset) in the dataset configuration. Creation of an `isr.py` does not require changes to Gen 3 `ap_verify`, which already allows for an optional `isr.py` in the dataset.