### PR TITLE
DM-31681: Create template generation and supporting scripts

### DIFF
--- a/pipelines/ApTemplate.yaml
+++ b/pipelines/ApTemplate.yaml
@@ -1,0 +1,12 @@
+description: Alert Production template building pipeline specialized for HiTS-2015
+# This pipeline assumes the working repo has raws, calibs, refcats, and a skymap,
+# and that you have already run the RunIsrForCrosstalkSources.yaml pipeline.
+
+imports:
+  - location: $AP_PIPE_DIR/pipelines/DarkEnergyCamera/ApTemplate.yaml
+parameters:
+  coaddName: deep
+  # TODO: redundant connection definitions workaround for DM-30210
+  selectedVisits: deepVisits
+  template: deepCoadd
+  # TODO: end DM-30210 workaround

--- a/scripts/generate_calibs_gen3.sh
+++ b/scripts/generate_calibs_gen3.sh
@@ -1,4 +1,3 @@
-#!/bin/bash
 # This file is part of ap_verify_hits2015.
 #
 # Developed for the LSST Data Management System.
@@ -20,92 +19,18 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-# Script for automatically generating calibs for this dataset. It takes roughly
-# 6 hours to run on lsst-devl.
-# Running this script allows for calibs to incorporate pipeline improvements.
-# It makes no attempt to update the set of input exposures or their validity
-# ranges; they are hard-coded into the file.
-#
-# Example:
-# $ nohup generate_calibs_gen3.sh -c "u/me/DM-123456" &
-# produces certified calibs in /repo/main in the u/me/DM-123456-calib
-# collection. See generate_calibs_gen3.sh -h for more options.
+# Common code for generate_calibs_gen3_*.
+# This script is intended to be included by other scripts, rather than
+# called directly.
 
 # Abort script on any error
 set -e
 
 ########################################
-# Raw calibs to process
-
-# Syntax matters -- use
-#     https://pipelines.lsst.io/v/daily/modules/lsst.daf.butler/queries.html#dimension-expressions
-#     syntax, with no trailing comma.
-
-declare -A EXPOSURES_BIAS
-EXPOSURES_BIAS[20150216]='410714, 410715, 410716, 410717, 410718, 410719, 410720, 410721, 410722,
-                          410723, 410724'
-EXPOSURES_BIAS[20150217]='411102, 411103, 411104, 411105, 411106, 411107, 411108, 411109, 411110,
-                          411111, 411112'
-EXPOSURES_BIAS[20150218]='411502, 411503, 411504, 411505, 411506, 411507, 411508, 411509, 411510,
-                          411511, 411512'
-EXPOSURES_BIAS[20150219]='411904, 411905, 411906, 411907, 411908, 411909, 411910, 411911, 411912,
-                          411913, 411914'
-EXPOSURES_BIAS[20150220]='412096, 412097, 412098, 412099, 412100, 412101, 412102, 412103, 412104,
-                          412105, 412106'
-EXPOSURES_BIAS[20150221]='412355, 412356, 412357, 412358, 412359, 412360, 412361, 412362, 412363,
-                          412364, 412365'
-EXPOSURES_BIAS[20150223]='413448, 413449, 413450, 413451, 413452, 413453, 413454, 413455, 413456,
-                          413457, 413458'
-EXPOSURES_BIAS[20150226]='415136, 415137, 415138, 415139, 415140, 415141, 415142, 415143, 415144,
-                          415145, 415146'
-EXPOSURES_BIAS[20150313]='421350, 421351, 421352, 421353, 421354, 421355, 421356, 421357, 421358,
-                          421359, 421360'
-
-declare -A VALIDITIES_BIAS
-VALIDITIES_BIAS[20150216]='--begin-date 2015-02-01T00:00:00 --end-date 2015-02-16T23:59:59'
-VALIDITIES_BIAS[20150217]='--begin-date 2015-02-17T00:00:00 --end-date 2015-02-17T23:59:59'
-VALIDITIES_BIAS[20150218]='--begin-date 2015-02-18T00:00:00 --end-date 2015-02-18T23:59:59'
-VALIDITIES_BIAS[20150219]='--begin-date 2015-02-19T00:00:00 --end-date 2015-02-19T23:59:59'
-VALIDITIES_BIAS[20150220]='--begin-date 2015-02-20T00:00:00 --end-date 2015-02-20T23:59:59'
-VALIDITIES_BIAS[20150221]='--begin-date 2015-02-21T00:00:00 --end-date 2015-02-22T23:59:59'
-VALIDITIES_BIAS[20150223]='--begin-date 2015-02-23T00:00:00 --end-date 2015-02-24T23:59:59'
-VALIDITIES_BIAS[20150226]='--begin-date 2015-02-25T00:00:00 --end-date 2015-03-05T23:59:59'
-VALIDITIES_BIAS[20150313]='--begin-date 2015-03-06T00:00:00 --end-date 2015-03-15T23:59:59'
-
-declare -A EXPOSURES_FLAT_g_c0001
-EXPOSURES_FLAT_g_c0001[20150216]='410790, 410791, 410792, 410793, 410794, 410795, 410796, 410797,
-                                  410798, 410799, 410800'
-EXPOSURES_FLAT_g_c0001[20150217]='411178, 411179, 411180, 411181, 411182, 411183, 411184, 411185,
-                                  411186, 411187, 411188'
-EXPOSURES_FLAT_g_c0001[20150218]='411578, 411579, 411580, 411581, 411582, 411583, 411584, 411585,
-                                  411586, 411587, 411588'
-EXPOSURES_FLAT_g_c0001[20150219]='411980, 411981, 411982, 411983, 411984, 411985, 411986, 411987,
-                                  411988, 411989, 411990'
-EXPOSURES_FLAT_g_c0001[20150220]='412172, 412173, 412174, 412175, 412176, 412177, 412178, 412179,
-                                  412180, 412181, 412182'
-EXPOSURES_FLAT_g_c0001[20150221]='412431, 412432, 412433, 412434, 412435, 412436, 412437, 412438,
-                                  412439, 412440, 412441'
-EXPOSURES_FLAT_g_c0001[20150223]='413524, 413525, 413526, 413527, 413528, 413529, 413530, 413531,
-                                  413532, 413533, 413534'
-EXPOSURES_FLAT_g_c0001[20150226]='415212, 415213, 415214, 415215, 415216, 415217, 415218, 415219,
-                                  415220, 415221, 415222'
-EXPOSURES_FLAT_g_c0001[20150313]='421426, 421427, 421428, 421429, 421430, 421431, 421432, 421433,
-                                  421434, 421435, 421436'
-
-declare -A VALIDITIES_FLAT_g_c0001
-VALIDITIES_FLAT_g_c0001[20150216]='--begin-date 2015-02-01T00:00:00 --end-date 2015-02-16T23:59:59'
-VALIDITIES_FLAT_g_c0001[20150217]='--begin-date 2015-02-17T00:00:00 --end-date 2015-02-17T23:59:59'
-VALIDITIES_FLAT_g_c0001[20150218]='--begin-date 2015-02-18T00:00:00 --end-date 2015-02-18T23:59:59'
-VALIDITIES_FLAT_g_c0001[20150219]='--begin-date 2015-02-19T00:00:00 --end-date 2015-02-19T23:59:59'
-VALIDITIES_FLAT_g_c0001[20150220]='--begin-date 2015-02-20T00:00:00 --end-date 2015-02-20T23:59:59'
-VALIDITIES_FLAT_g_c0001[20150221]='--begin-date 2015-02-21T00:00:00 --end-date 2015-02-22T23:59:59'
-VALIDITIES_FLAT_g_c0001[20150223]='--begin-date 2015-02-23T00:00:00 --end-date 2015-02-24T23:59:59'
-VALIDITIES_FLAT_g_c0001[20150226]='--begin-date 2015-02-25T00:00:00 --end-date 2015-03-05T23:59:59'
-VALIDITIES_FLAT_g_c0001[20150313]='--begin-date 2015-03-06T00:00:00 --end-date 2015-03-15T23:59:59'
+# Variable management
 
 # from https://stackoverflow.com/questions/1527049/how-can-i-join-elements-of-an-array-in-bash
 join_by() { local IFS="$1"; shift; echo "$*"; }
-EXPOSURES_CROSSTALK=`join_by , "${EXPOSURES_FLAT_g_c0001[@]}"`
 
 
 ########################################
@@ -126,22 +51,24 @@ usage() {
     exit 1
 }
 
-while getopts "b:c:h" option; do
-    case "$option" in
-        b)  BUTLER_REPO="$OPTARG";;
-        c)  COLLECT_ROOT="$OPTARG";;
-        h)  usage;;
-        *)  usage;;
-    esac
-done
-if [[ -z "${BUTLER_REPO}" ]]; then
-    BUTLER_REPO="/repo/main"
-fi
-if [[ -z "${COLLECT_ROOT}" ]]; then
-    print_error "$0: mandatory argument -- c"
-    usage
-    exit 1
-fi
+parse_args() {
+    while getopts "b:c:h" option $@; do
+        case "$option" in
+            b)  BUTLER_REPO="$OPTARG";;
+            c)  COLLECT_ROOT="$OPTARG";;
+            h)  usage;;
+            *)  usage;;
+        esac
+    done
+    if [[ -z "${BUTLER_REPO}" ]]; then
+        BUTLER_REPO="/repo/main"
+    fi
+    if [[ -z "${COLLECT_ROOT}" ]]; then
+        print_error "$0: mandatory argument -- c"
+        usage
+        exit 1
+    fi
+}
 
 
 ########################################
@@ -149,40 +76,61 @@ fi
 
 # TODO: overscan.fitType override may be included in cp_pipe on DM-30651
 
-pipetask run -j 12 -d "exposure IN ($EXPOSURES_CROSSTALK) AND instrument='DECam'" \
-    -b ${BUTLER_REPO} -i DECam/defaults -o ${COLLECT_ROOT}-crosstalk-sources \
-    -p $CP_PIPE_DIR/pipelines/DarkEnergyCamera/RunIsrForCrosstalkSources.yaml \
-    -c overscan:overscan.fitType='MEDIAN_PER_ROW'
+do_crosstalk() {
+    local repo="$1"       # Butler URI
+    local collect="$2"    # Partial collection name
+    local exposures="$3"  # Comma-delimited list of exposure IDs
+    pipetask run -j 12 -d "exposure IN ($exposures) AND instrument='DECam'" \
+        -b ${repo} -i DECam/defaults -o ${collect}-crosstalk-sources \
+        -p $CP_PIPE_DIR/pipelines/DarkEnergyCamera/RunIsrForCrosstalkSources.yaml \
+        -c overscan:overscan.fitType='MEDIAN_PER_ROW'
+}
 
 ########################################
 # Build and certify bias frames
 
 # TODO: overscan.fitType override may be included in cp_pipe on DM-30651
 
-for date in ${!EXPOSURES_BIAS[*]}; do
-    pipetask run -j 12 -d "exposure IN (${EXPOSURES_BIAS[${date}]}) AND instrument='DECam'" \
-        -b ${BUTLER_REPO} -i DECam/defaults -o ${COLLECT_ROOT}-bias-construction-${date} \
-        -p $CP_PIPE_DIR/pipelines/cpBias.yaml -c isr:overscan.fitType='MEDIAN_PER_ROW'
-    butler certify-calibrations ${BUTLER_REPO} ${COLLECT_ROOT}-bias-construction-${date} \
-        ${COLLECT_ROOT}-calib bias ${VALIDITIES_BIAS[${date}]}
-done
+do_bias() {
+    local repo="$1"                    # Butler URI
+    local collect="$2"                 # Partial collection name
+    # Associative array hack from https://stackoverflow.com/questions/4069188/
+    # Arrays must be passed as strings from calling declare -p.
+    # Associative array of coma-delimited list of exposure IDs, keyed by 1-word "date"
+    eval "local -A exposures=${3#*=}"
+    # Associative array of "--begin-date --end-date", with same keys as $exposures
+    eval "local -A validities=${4#*=}"
+
+    for date in ${!exposures[*]}; do
+        pipetask run -j 12 -d "exposure IN (${exposures[${date}]}) AND instrument='DECam'" \
+            -b ${repo} -i DECam/defaults -o ${collect}-bias-construction-${date} \
+            -p $CP_PIPE_DIR/pipelines/cpBias.yaml -c isr:overscan.fitType='MEDIAN_PER_ROW'
+        butler certify-calibrations ${repo} ${collect}-bias-construction-${date} \
+            ${collect}-calib bias ${validities[${date}]}
+    done
+}
 
 ########################################
 # Build and certify flat frames
 
 # TODO: cpFlatNorm:level override may be included in cp_pipe on DM-30651
 
-for date in ${!EXPOSURES_FLAT_g_c0001[*]}; do
-    pipetask run -j 12 -d "exposure IN (${EXPOSURES_FLAT_g_c0001[${date}]}) AND instrument='DECam'" \
-        -b ${BUTLER_REPO} -i DECam/defaults,${COLLECT_ROOT}-calib,${COLLECT_ROOT}-crosstalk-sources \
-        -o ${COLLECT_ROOT}-flat-construction-${date} \
-        -p $CP_PIPE_DIR/pipelines/DarkEnergyCamera/cpFlat.yaml -c cpFlatNorm:level='AMP'
-    butler certify-calibrations ${BUTLER_REPO} ${COLLECT_ROOT}-flat-construction-${date} \
-        ${COLLECT_ROOT}-calib flat ${VALIDITIES_FLAT_g_c0001[${date}]}
-done
+do_flat() {
+    local repo="$1"                    # Butler URI
+    local collect="$2"                 # Partial collection name
+    # Associative array hack from https://stackoverflow.com/questions/4069188/
+    # Arrays must be passed as strings from calling declare -p.
+    # Associative array of coma-delimited list of exposure IDs, keyed by 1-word "date"
+    eval "local -A exposures=${3#*=}"
+    # Associative array of "--begin-date --end-date", with same keys as $exposures
+    eval "local -A validities=${4#*=}"
 
-
-########################################
-# Final summary
-
-echo "Biases and flats stored in ${BUTLER_REPO}:${COLLECT_ROOT}-calib"
+    for date in ${!exposures[*]}; do
+        pipetask run -j 12 -d "exposure IN (${exposures[${date}]}) AND instrument='DECam'" \
+            -b ${repo} -i DECam/defaults,${collect}-calib,${collect}-crosstalk-sources \
+            -o ${collect}-flat-construction-${date} \
+            -p $CP_PIPE_DIR/pipelines/DarkEnergyCamera/cpFlat.yaml -c cpFlatNorm:level='AMP'
+        butler certify-calibrations ${repo} ${collect}-flat-construction-${date} \
+            ${collect}-calib flat ${validities[${date}]}
+    done
+}

--- a/scripts/generate_calibs_gen3_science.sh
+++ b/scripts/generate_calibs_gen3_science.sh
@@ -1,0 +1,132 @@
+#!/bin/bash
+# This file is part of ap_verify_hits2015.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+# Script for automatically generating calibs for this dataset. It takes roughly
+# 6 hours to run on lsst-devl.
+# Running this script allows for calibs to incorporate pipeline improvements.
+# It makes no attempt to update the set of input exposures or their validity
+# ranges; they are hard-coded into the file.
+#
+# Example:
+# $ nohup generate_calibs_gen3_science.sh -c "u/me/DM-123456" &
+# produces certified calibs in /repo/main in the u/me/DM-123456-calib
+# collection. See generate_calibs_gen3_science.sh -h for more options.
+
+
+# Common definitions
+SCRIPT_DIR="$( dirname -- "${BASH_SOURCE[0]}" )"
+source "${SCRIPT_DIR}/generate_calibs_gen3.sh"
+
+
+########################################
+# Raw calibs to process
+
+# Syntax matters -- use
+#     https://pipelines.lsst.io/v/daily/modules/lsst.daf.butler/queries.html#dimension-expressions
+#     syntax, with no trailing comma.
+
+declare -A EXPOSURES_BIAS
+EXPOSURES_BIAS[20150216]='410714, 410715, 410716, 410717, 410718, 410719, 410720, 410721, 410722,
+                          410723, 410724'
+EXPOSURES_BIAS[20150217]='411102, 411103, 411104, 411105, 411106, 411107, 411108, 411109, 411110,
+                          411111, 411112'
+EXPOSURES_BIAS[20150218]='411502, 411503, 411504, 411505, 411506, 411507, 411508, 411509, 411510,
+                          411511, 411512'
+EXPOSURES_BIAS[20150219]='411904, 411905, 411906, 411907, 411908, 411909, 411910, 411911, 411912,
+                          411913, 411914'
+EXPOSURES_BIAS[20150220]='412096, 412097, 412098, 412099, 412100, 412101, 412102, 412103, 412104,
+                          412105, 412106'
+EXPOSURES_BIAS[20150221]='412355, 412356, 412357, 412358, 412359, 412360, 412361, 412362, 412363,
+                          412364, 412365'
+EXPOSURES_BIAS[20150223]='413448, 413449, 413450, 413451, 413452, 413453, 413454, 413455, 413456,
+                          413457, 413458'
+EXPOSURES_BIAS[20150226]='415136, 415137, 415138, 415139, 415140, 415141, 415142, 415143, 415144,
+                          415145, 415146'
+EXPOSURES_BIAS[20150313]='421350, 421351, 421352, 421353, 421354, 421355, 421356, 421357, 421358,
+                          421359, 421360'
+
+declare -A VALIDITIES_BIAS
+VALIDITIES_BIAS[20150216]='--begin-date 2015-02-01T00:00:00 --end-date 2015-02-16T23:59:59'
+VALIDITIES_BIAS[20150217]='--begin-date 2015-02-17T00:00:00 --end-date 2015-02-17T23:59:59'
+VALIDITIES_BIAS[20150218]='--begin-date 2015-02-18T00:00:00 --end-date 2015-02-18T23:59:59'
+VALIDITIES_BIAS[20150219]='--begin-date 2015-02-19T00:00:00 --end-date 2015-02-19T23:59:59'
+VALIDITIES_BIAS[20150220]='--begin-date 2015-02-20T00:00:00 --end-date 2015-02-20T23:59:59'
+VALIDITIES_BIAS[20150221]='--begin-date 2015-02-21T00:00:00 --end-date 2015-02-22T23:59:59'
+VALIDITIES_BIAS[20150223]='--begin-date 2015-02-23T00:00:00 --end-date 2015-02-24T23:59:59'
+VALIDITIES_BIAS[20150226]='--begin-date 2015-02-25T00:00:00 --end-date 2015-03-05T23:59:59'
+VALIDITIES_BIAS[20150313]='--begin-date 2015-03-06T00:00:00 --end-date 2015-03-15T23:59:59'
+
+declare -A EXPOSURES_FLAT_g_c0001
+EXPOSURES_FLAT_g_c0001[20150216]='410790, 410791, 410792, 410793, 410794, 410795, 410796, 410797,
+                                  410798, 410799, 410800'
+EXPOSURES_FLAT_g_c0001[20150217]='411178, 411179, 411180, 411181, 411182, 411183, 411184, 411185,
+                                  411186, 411187, 411188'
+EXPOSURES_FLAT_g_c0001[20150218]='411578, 411579, 411580, 411581, 411582, 411583, 411584, 411585,
+                                  411586, 411587, 411588'
+EXPOSURES_FLAT_g_c0001[20150219]='411980, 411981, 411982, 411983, 411984, 411985, 411986, 411987,
+                                  411988, 411989, 411990'
+EXPOSURES_FLAT_g_c0001[20150220]='412172, 412173, 412174, 412175, 412176, 412177, 412178, 412179,
+                                  412180, 412181, 412182'
+EXPOSURES_FLAT_g_c0001[20150221]='412431, 412432, 412433, 412434, 412435, 412436, 412437, 412438,
+                                  412439, 412440, 412441'
+EXPOSURES_FLAT_g_c0001[20150223]='413524, 413525, 413526, 413527, 413528, 413529, 413530, 413531,
+                                  413532, 413533, 413534'
+EXPOSURES_FLAT_g_c0001[20150226]='415212, 415213, 415214, 415215, 415216, 415217, 415218, 415219,
+                                  415220, 415221, 415222'
+EXPOSURES_FLAT_g_c0001[20150313]='421426, 421427, 421428, 421429, 421430, 421431, 421432, 421433,
+                                  421434, 421435, 421436'
+
+declare -A VALIDITIES_FLAT_g_c0001
+VALIDITIES_FLAT_g_c0001[20150216]='--begin-date 2015-02-01T00:00:00 --end-date 2015-02-16T23:59:59'
+VALIDITIES_FLAT_g_c0001[20150217]='--begin-date 2015-02-17T00:00:00 --end-date 2015-02-17T23:59:59'
+VALIDITIES_FLAT_g_c0001[20150218]='--begin-date 2015-02-18T00:00:00 --end-date 2015-02-18T23:59:59'
+VALIDITIES_FLAT_g_c0001[20150219]='--begin-date 2015-02-19T00:00:00 --end-date 2015-02-19T23:59:59'
+VALIDITIES_FLAT_g_c0001[20150220]='--begin-date 2015-02-20T00:00:00 --end-date 2015-02-20T23:59:59'
+VALIDITIES_FLAT_g_c0001[20150221]='--begin-date 2015-02-21T00:00:00 --end-date 2015-02-22T23:59:59'
+VALIDITIES_FLAT_g_c0001[20150223]='--begin-date 2015-02-23T00:00:00 --end-date 2015-02-24T23:59:59'
+VALIDITIES_FLAT_g_c0001[20150226]='--begin-date 2015-02-25T00:00:00 --end-date 2015-03-05T23:59:59'
+VALIDITIES_FLAT_g_c0001[20150313]='--begin-date 2015-03-06T00:00:00 --end-date 2015-03-15T23:59:59'
+
+EXPOSURES_CROSSTALK=$(join_by , "${EXPOSURES_FLAT_g_c0001[@]}")
+
+
+########################################
+# Command-line options
+
+parse_args "$@"
+
+
+########################################
+# Generate calibs
+
+do_crosstalk $BUTLER_REPO $COLLECT_ROOT "$EXPOSURES_CROSSTALK"
+
+# Associative array hack from https://stackoverflow.com/questions/4069188/
+do_bias $BUTLER_REPO $COLLECT_ROOT "$(declare -p EXPOSURES_BIAS)" "$(declare -p VALIDITIES_BIAS)"
+do_flat $BUTLER_REPO $COLLECT_ROOT \
+    "$(declare -p EXPOSURES_FLAT_g_c0001)" "$(declare -p VALIDITIES_FLAT_g_c0001)"
+
+
+########################################
+# Final summary
+
+echo "Biases and flats stored in ${BUTLER_REPO}:${COLLECT_ROOT}-calib"

--- a/scripts/generate_calibs_gen3_template.sh
+++ b/scripts/generate_calibs_gen3_template.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+# This file is part of ap_verify_hits2015.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+# Script for automatically generating template calibs for this dataset. It
+# takes roughly 4 hours to run on lsst-devl.
+# This script should be run before generating templates in order to
+# self-consistently use all pipeline improvements.
+#
+# Example:
+# $ nohup generate_calibs_gen3_template.sh -c "u/me/DM-123456" &
+# produces certified calibs in /repo/main in the u/me/DM-123456-calib
+# collection. See generate_calibs_gen3_template.sh -h for more options.
+
+
+# Common definitions
+SCRIPT_DIR="$( dirname -- "${BASH_SOURCE[0]}" )"
+source "${SCRIPT_DIR}/generate_calibs_gen3.sh"
+
+
+########################################
+# Raw calibs to process
+
+# Syntax matters -- use
+#     https://pipelines.lsst.io/v/daily/modules/lsst.daf.butler/queries.html#dimension-expressions
+#     syntax, with no trailing comma.
+
+declare -A EXPOSURES_BIAS
+EXPOSURES_BIAS[20140228]='288902, 288903, 288904, 288905, 288906, 288907, 288908, 288909, 288910,
+                          288911, 288912'
+EXPOSURES_BIAS[20140301]='289119, 289120, 289121, 289122, 289123, 289124, 289125, 289126, 289127,
+                          289128, 289129'
+EXPOSURES_BIAS[20140302]='289328, 289329, 289330, 289331, 289332, 289333, 289334, 289335, 289336,
+                          289337, 289338'
+EXPOSURES_BIAS[20140303]='289532, 289533, 289534, 289535, 289536, 289537, 289538, 289539, 289540,
+                          289541, 289542'
+EXPOSURES_BIAS[20140304]='289742, 289743, 289744, 289745, 289746, 289747, 289748, 289749, 289750,
+                          289751, 289752'
+
+declare -A VALIDITIES_BIAS
+VALIDITIES_BIAS[20140228]='--begin-date 2014-02-15T00:00:00 --end-date 2014-02-28T23:59:59'
+VALIDITIES_BIAS[20140301]='--begin-date 2014-03-01T00:00:00 --end-date 2014-03-01T23:59:59'
+VALIDITIES_BIAS[20140302]='--begin-date 2014-03-02T00:00:00 --end-date 2014-03-02T23:59:59'
+VALIDITIES_BIAS[20140303]='--begin-date 2014-03-03T00:00:00 --end-date 2014-03-03T23:59:59'
+VALIDITIES_BIAS[20140304]='--begin-date 2014-03-04T00:00:00 --end-date 2014-03-15T23:59:59'
+
+declare -A EXPOSURES_FLAT_g_c0001
+EXPOSURES_FLAT_g_c0001[20140228]='288847, 288848, 288849, 288850, 288851, 288852, 288853, 288854,
+                                  288855, 288856, 288857'
+EXPOSURES_FLAT_g_c0001[20140301]='289130, 289131, 289132, 289133, 289134, 289135, 289136, 289137,
+                                  289138, 289139, 289140'
+EXPOSURES_FLAT_g_c0001[20140302]='289339, 289340, 289341, 289342, 289343, 289344, 289345, 289346,
+                                  289347, 289348, 289349'
+EXPOSURES_FLAT_g_c0001[20140303]='289543, 289544, 289545, 289546, 289547, 289548, 289549, 289550,
+                                  289551, 289552, 289553'
+EXPOSURES_FLAT_g_c0001[20140304]='289753, 289754, 289755, 289756, 289757, 289758, 289759, 289760,
+                                  289761, 289762, 289763'
+
+declare -A VALIDITIES_FLAT_g_c0001
+VALIDITIES_FLAT_g_c0001[20140228]='--begin-date 2014-02-15T00:00:00 --end-date 2014-02-28T23:59:59'
+VALIDITIES_FLAT_g_c0001[20140301]='--begin-date 2014-03-01T00:00:00 --end-date 2014-03-01T23:59:59'
+VALIDITIES_FLAT_g_c0001[20140302]='--begin-date 2014-03-02T00:00:00 --end-date 2014-03-02T23:59:59'
+VALIDITIES_FLAT_g_c0001[20140303]='--begin-date 2014-03-03T00:00:00 --end-date 2014-03-03T23:59:59'
+VALIDITIES_FLAT_g_c0001[20140304]='--begin-date 2014-03-04T00:00:00 --end-date 2014-03-15T23:59:59'
+
+EXPOSURES_CROSSTALK=$(join_by , "${EXPOSURES_FLAT_g_c0001[@]}")
+
+
+########################################
+# Command-line options
+
+parse_args "$@"
+
+
+########################################
+# Generate calibs
+
+do_crosstalk $BUTLER_REPO $COLLECT_ROOT "$EXPOSURES_CROSSTALK"
+
+# Associative array hack from https://stackoverflow.com/questions/4069188/
+do_bias $BUTLER_REPO $COLLECT_ROOT "$(declare -p EXPOSURES_BIAS)" "$(declare -p VALIDITIES_BIAS)"
+do_flat $BUTLER_REPO $COLLECT_ROOT \
+    "$(declare -p EXPOSURES_FLAT_g_c0001)" "$(declare -p VALIDITIES_FLAT_g_c0001)"
+
+
+########################################
+# Final summary
+
+echo "Biases and flats stored in ${BUTLER_REPO}:${COLLECT_ROOT}-calib"

--- a/scripts/generate_templates_gen3.sh
+++ b/scripts/generate_templates_gen3.sh
@@ -1,0 +1,118 @@
+#!/bin/bash
+# This file is part of ap_verify_hits2015.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+# Script for automatically generating differencing templates for this dataset.
+# It takes roughly 24 hours to run on lsst-devl.
+# Running this script allows for templates to incorporate pipeline
+# improvements. It makes no attempt to update the set of input exposures; they
+# are hard-coded into the file.
+#
+# Example:
+# $ nohup generate_templates_gen3.sh -c "u/me/DM-123456-calib" -o "u/me/DM-123456-template" &
+# produces templates in /repo/main in the u/me/DM-123456-template collection.
+# See generate_templates_gen3.sh -h for more options.
+
+
+# Abort script on any error
+set -e
+
+
+########################################
+# Raw template exposures to process
+
+FIELDS="'Blind14A_04', 'Blind14A_09', 'Blind14A_10'"
+EXPOSURES="288929, 288934, 288935, 288970, 288975, 288976, 289010, 289015, 289016, 289050, 289055,
+           289056, 289155, 289160, 289161, 289196, 289201, 289202, 289237, 289242, 289243, 289278,
+           289283, 289284, 289362, 289367, 289368, 289403, 289408, 289409, 289444, 289449, 289450,
+           289486, 289492, 289493, 289567, 289572, 289573, 289608, 289613, 289614, 289650, 289655,
+           289656, 289691, 289696, 289697, 289782, 289783, 289818, 289820, 289823, 289828, 289865,
+           289870, 289871, 289907, 289912, 289913"
+DATE_CUTOFF=20141231
+
+
+########################################
+# Command-line options
+
+print_error() {
+    >&2 echo "$@"
+}
+
+usage() {
+    print_error
+    print_error "Usage: $0 [-b BUTLER_REPO] -c ROOT_COLLECTION [-h]"
+    print_error
+    print_error "Specific options:"
+    print_error "   -b          Butler repo URI, defaults to /repo/main"
+    print_error "   -c          input calib collection for template processing"
+    print_error "   -o          template collection name"
+    print_error "   -h          show this message"
+    exit 1
+}
+
+parse_args() {
+    while getopts "b:c:o:h" option $@; do
+        case "$option" in
+            b)  BUTLER_REPO="$OPTARG";;
+            c)  CALIBS="$OPTARG";;
+            o)  TEMPLATES="$OPTARG";;
+            h)  usage;;
+            *)  usage;;
+        esac
+    done
+    if [[ -z "${BUTLER_REPO}" ]]; then
+        BUTLER_REPO="/repo/main"
+    fi
+    if [[ -z "${CALIBS}" ]]; then
+        print_error "$0: mandatory argument -- c"
+        usage
+        exit 1
+    fi
+    if [[ -z "${TEMPLATES}" ]]; then
+        print_error "$0: mandatory argument -- o"
+        usage
+        exit 1
+    fi
+}
+parse_args "$@"
+
+
+########################################
+# Generate templates
+
+FILTER="instrument='DECam' AND exposure IN (${EXPOSURES}) AND detector NOT IN (2, 61)"
+
+pipetask run -j 12 -d "${FILTER}" -b ${BUTLER_REPO} -i DECam/defaults,${CALIBS} -o ${TEMPLATES} \
+    -p $AP_PIPE_DIR/pipelines/DarkEnergyCamera/RunIsrForCrosstalkSources.yaml
+
+# Run single-frame processing and coaddition separately, so that isolated
+# errors in SFP do not prevent coaddition from running. Instead, coadds will
+# use all successful runs, ignoring any failures.
+pipetask run -j 12 -d "${FILTER}" -b ${BUTLER_REPO} -o ${TEMPLATES} \
+    -p $AP_VERIFY_HITS2015_DIR/pipelines/ApTemplate.yaml#singleFrameAp
+pipetask run -j 12 -d "${FILTER}" -b ${BUTLER_REPO} -o ${TEMPLATES} \
+    -p $AP_VERIFY_HITS2015_DIR/pipelines/ApTemplate.yaml#makeTemplate
+
+
+########################################
+# Final summary
+
+echo "Templates stored in ${BUTLER_REPO}:${TEMPLATES}"


### PR DESCRIPTION
This PR refactors the calib generation script added in #30 and adds scripts for template calibs and templates. All scripts are currently standalone, but will be incorporated into a more general dataset management tool in [DM-29857](https://jira.lsstcorp.org/browse/DM-29857).