### PR TITLE
DM-36385: Deprecate ap_verify_hits2015 dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ This and other `ap_verify` "datasets" are based on [ap_verify_dataset_template](
 
 Contains g-band DECam data from the HiTS (2015) fields `Blind15A_26`, `Blind15A_40`, and `Blind15A_42`.
 
+*Warning:* This package is deprecated, and will be removed from the Rubin Observatory Science Pipelines distribution after release 25.0.0.
+
 ---
 **Note**
 

--- a/config/calibrate.py
+++ b/config/calibrate.py
@@ -1,5 +1,10 @@
 # Config override for lsst.pipe.tasks.calibrate.CalibrateTask
 
+import warnings
+
+warnings.warn('ap_verify_hits2015 is deprecated; it will be removed from the Rubin Observatory '
+              'Science Pipelines after release 25.0.0', category=FutureWarning)
+
 # Use gaia for astrometry (phot_g_mean for everything, as that is the broadest
 # band with the most depth)
 config.connections.astromRefCat = "gaia"

--- a/doc/ap_verify_hits2015/index.rst
+++ b/doc/ap_verify_hits2015/index.rst
@@ -9,6 +9,10 @@ It is a good example dataset for difference imaging with DECam.
 
 .. _HiTS: https://doi.org/10.3847/0004-637X/832/2/155
 
+.. warning::
+
+   This package is deprecated, and will be removed from the Rubin Observatory Science Pipelines after release 25.0.0.
+
 .. _ap_verify_hits2015-using:
 
 Using ap_verify_hits2015


### PR DESCRIPTION
This PR adds standard deprecation warnings to `ap_verify_hits2015`. The config warning only appears several minutes into an `ap_verify.py` run, but I couldn't find a portable way to make it appear on dataset selection.